### PR TITLE
Frontend page setup

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -3694,6 +3694,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA=="
     },
+    "clappr": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/clappr/-/clappr-0.3.13.tgz",
+      "integrity": "sha512-cAtGhtSAYIavKqVQb/wX5pB9twb/W7gFUGBaGHy6dbpUqCtCmtH0Eu05rNSwtbaREWgSTUJyEMTgaNSZ/62KlQ=="
+    },
     "classnames": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.1.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5801,6 +5801,14 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
     },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
+    },
     "hoopy": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/hoopy/-/hoopy-0.1.4.tgz",
@@ -9538,6 +9546,23 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+    },
+    "react-router": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.2.2.tgz",
+      "integrity": "sha512-/MbxyLzd7Q7amp4gDOGaYvXwhEojkJD5BtExkuKmj39VEE0m3l/zipf6h2WIB2jyAO0lI6NGETh4RDcktRm4AQ==",
+      "requires": {
+        "history": "^5.2.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.2.2.tgz",
+      "integrity": "sha512-AtYEsAST7bDD4dLSQHDnk/qxWLJdad5t1HFa1qJyUrCeGgEuCSw0VB/27ARbF9Fi/W5598ujvJOm3ujUCVzuYQ==",
+      "requires": {
+        "history": "^5.2.0",
+        "react-router": "6.2.2"
+      }
     },
     "react-scripts": {
       "version": "5.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -13,6 +13,7 @@
     "jquery": "^3.6.0",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-router-dom": "^6.2.2",
     "react-scripts": "5.0.0",
     "reactstrap": "^8.9.0",
     "universal-cookie": "^4.0.4",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^0.21.1",
     "bootstrap": "^4.6.0",
+    "clappr": "^0.3.13",
     "cookies": "^0.8.0",
     "jquery": "^3.6.0",
     "react": "^17.0.2",

--- a/frontend/src/components/clappr-player.js
+++ b/frontend/src/components/clappr-player.js
@@ -1,4 +1,5 @@
 import Clappr from "clappr";
+import Cookies from 'universal-cookie';
 import { Component } from "react";
 
 class ClapprPlayer extends Component{
@@ -13,7 +14,8 @@ class ClapprPlayer extends Component{
             parentId: `#${id}`,
             source: source,
             plugins: [Clappr.FlasHLS],
-            mimeType: 'application/x-mpegURL'
+            mimeType: 'application/x-mpegURL',
+            withCredentials: true
         })
     }
 
@@ -25,6 +27,10 @@ class ClapprPlayer extends Component{
     render(){
 
         const id = this.props.id;
+        const cookies = new Cookies();
+        cookies.set('entitlement_token', 
+                    'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJFeHRlcm5hbEF1dGhvcml6YXRpb25zQ29udGV4dERhdGEiOiJVU0EiLCJTdWJzY3JpcHRpb25TdGF0dXMiOiJhY3RpdmUiLCJTdWJzY3JpYmVySWQiOiIxNzk3MDUzMzQiLCJGaXJzdE5hbWUiOiJHb3Jkb24iLCJMYXN0TmFtZSI6IkZyZWVtYW4iLCJTZXNzaW9uSWQiOiJleUowZVhBaU9pSktWMVFpTENKaGJHY2lPaUpJVXpJMU5pSjkuZXlKemFTSTZJall3WVRsaFpEZzBMV1U1TTJRdE5EZ3daaTA0TUdRMkxXRm1NemMwT1RSbU1tVXlNaUlzSW1KMUlqb2lNVEF3TVRFaUxDSnBaQ0k2SWpZd05UbGpaakU1TFRaaE9EUXRORGcyT1MxaVpqSm1MV0ZtWVRReFlUSmpaakF6WWlJc0ltd2lPaUpsYmkxSFFpSXNJbVJqSWpvaU16WTBOQ0lzSW5RaU9pSXhJaXdpWVdWa0lqb2lNakF5TWkwd05DMHdOMVF4TkRveE56b3lPQzQyTkRsYUlpd2laV1FpT2lJeU1ESXlMVEEwTFRJelZERTBPakUzT2pJNExqWTBPVm9pTENKalpXUWlPaUl5TURJeUxUQXpMVEkxVkRFME9qRTNPakk0TGpZME9Wb2lMQ0p1WVcxbGFXUWlPaUl4TnprM01EVXpNelFpTENKa2RDSTZJalFpTENKcGNDSTZJakUwT1M0MU55NHhOaTR4TkRraUxDSmpieUk2SWxWVFFTSXNJbWx6Y3lJNkltRnpZMlZ1Wkc5dUxuUjJJaXdpWVhWa0lqb2lZWE5qWlc1a2IyNHVkSFlpTENKbGVIQWlPakUyTlRBM01qTTBORGdzSW01aVppSTZNVFkwT0RFek1UUTBPSDAuSTk0V3JXdE5PdlNCeFEydmxIVTFwRGpONzg4NnB1UUU3ejlBVHhBekRlYyIsIlN1YnNjcmliZWRQcm9kdWN0IjoiRjEgVFYgUHJvIE1vbnRobHkiLCJqdGkiOiIwZjBmOWM4ZC05MGY3LTRhZmEtOTdkMC0zZTY1ODRlM2VlMjQiLCJTdWJzY3JpcHRpb24iOiJQUk8iLCJpYXQiOjE2NDgxMzQxMzQsImV4cCI6MTY0ODQ3OTczNCwiaXNzIjoiRjEifQ.AKIc3PttHyiG_GQEqznaQ1q5bjw24D26n4FYl2Sl6SM',
+                    { path: '/'});
 
         return(
             <p id={id} />

--- a/frontend/src/components/clappr-player.js
+++ b/frontend/src/components/clappr-player.js
@@ -1,0 +1,35 @@
+import Clappr from "clappr";
+import { Component } from "react";
+
+class ClapprPlayer extends Component{
+    constructor(props){
+        super(props);
+    }
+    
+    componentDidMount(){
+        const { id, source } = this.props;
+
+        this.player = new Clappr.Player({
+            parentId: `#${id}`,
+            source: source,
+            plugins: [Clappr.FlasHLS],
+            mimeType: 'application/x-mpegURL'
+        })
+    }
+
+    componentWillUnmount(){
+        this.player.destroy();
+        this.player = null;
+    }
+
+    render(){
+
+        const id = this.props.id;
+
+        return(
+            <p id={id} />
+        )
+    }
+}
+
+export default ClapprPlayer;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -4,10 +4,18 @@ import 'bootstrap/dist/css/bootstrap.css';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import { Broadcast } from './pages/broadcast.js';
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    {/* <App /> */}
+    <Router>
+      <Routes>
+        <Route path="/" element={<App />}/>
+        <Route path="/broadcast" element={<Broadcast />}/>
+      </Routes>
+    </Router>
   </React.StrictMode>,
   document.getElementById('root')
 );

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -6,6 +6,9 @@ import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import { Broadcast } from './pages/broadcast.js';
+import { Dashboard } from './pages/dashboard.js';
+import { SecondScreen } from './pages/secondscreen.js'; 
+import { Waiting } from './pages/waiting.js';
 
 ReactDOM.render(
   <React.StrictMode>
@@ -14,6 +17,9 @@ ReactDOM.render(
       <Routes>
         <Route path="/" element={<App />}/>
         <Route path="/broadcast" element={<Broadcast />}/>
+        <Route path="/dashboard" element={<Dashboard />}/>
+        <Route path="/secondscreen" element={<SecondScreen />}/>
+        <Route path="/waiting" element={<Waiting />}/>
       </Routes>
     </Router>
   </React.StrictMode>,

--- a/frontend/src/pages/broadcast.js
+++ b/frontend/src/pages/broadcast.js
@@ -1,0 +1,9 @@
+import React from "react";
+
+export const Broadcast = () => {
+    return(
+        <h1>This is the broadcast page.</h1>
+    )
+}
+
+export default Broadcast;

--- a/frontend/src/pages/broadcast.js
+++ b/frontend/src/pages/broadcast.js
@@ -5,7 +5,7 @@ export const Broadcast = () => {
     return(
         <>
             <h1>This is the broadcast page.</h1>
-            <ClapprPlayer id="f1broadcast" source="https://ott-video-fer-cf.formula1.com/c8059270529e63e492b34317933c3dca/out/v1/834af65834644680841d7d003e10db38/33957307c5b848a6bea693bb400a7166/e4d49ef8077f4032a097e2b0c8a962bb/index.m3u8?kid=1042&exp=1648481423&ttl=1440&token=YYjp5RDKcRcdmd2~XdfZpb5Gf31NFZOOCLmz1SdHuqQ_"/>
+            <ClapprPlayer id="f1broadcast" source="https://ott-video-cf.formula1.com/f7b399c8cf81ac81/out/v1/0b7a94ad4ee84b168178c6d09d38cc9c/index.m3u8?kid=1042&exp=1648483567&ttl=1440&token=bONTcXJY0huabkJCHWpbHoJjiqwngH3q0J3NOxUlqms_&start=2022-03-27T16:00:04+00:00"/>
         </>
     )
 }

--- a/frontend/src/pages/broadcast.js
+++ b/frontend/src/pages/broadcast.js
@@ -1,8 +1,12 @@
 import React from "react";
+import ClapprPlayer from "../components/clappr-player.js";
 
 export const Broadcast = () => {
     return(
-        <h1>This is the broadcast page.</h1>
+        <>
+            <h1>This is the broadcast page.</h1>
+            <ClapprPlayer id="f1broadcast" source="https://ott-video-fer-cf.formula1.com/c8059270529e63e492b34317933c3dca/out/v1/834af65834644680841d7d003e10db38/33957307c5b848a6bea693bb400a7166/e4d49ef8077f4032a097e2b0c8a962bb/index.m3u8?kid=1042&exp=1648481423&ttl=1440&token=YYjp5RDKcRcdmd2~XdfZpb5Gf31NFZOOCLmz1SdHuqQ_"/>
+        </>
     )
 }
 

--- a/frontend/src/pages/dashboard.js
+++ b/frontend/src/pages/dashboard.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+export const Dashboard = () => {
+    return(
+        <>
+            <h1>This is the dashboard.</h1>
+        </>
+    )
+}
+
+export default Dashboard;

--- a/frontend/src/pages/secondscreen.js
+++ b/frontend/src/pages/secondscreen.js
@@ -1,0 +1,11 @@
+import React from "react";
+
+export const SecondScreen = () => {
+    return(
+        <>
+            <h1>This is the second screen page.</h1>
+        </>
+    )
+}
+
+export default SecondScreen;

--- a/frontend/src/pages/waiting.js
+++ b/frontend/src/pages/waiting.js
@@ -1,0 +1,12 @@
+import React from "react";
+
+export const Waiting = () => {
+    return(
+        <>
+            <h1>Screen ready. Assign it something from your control device.</h1>
+            <p>Session ID: [session id goes here]</p>
+        </>
+    )
+}
+
+export default Waiting;


### PR DESCRIPTION
Added all pages to site (mostly boilerplate).

Created page to contain the broadcast with a Clappr player implementation. Doesn't currently work for F1 HLS due to F1 security policies involving cookies. Attempted to solve this by adding the entitlement token into a cookie but my best guess is that F1 checks that the cookie is from F1's own domain, which is hard to do.