### PR TITLE
Displaying telemetry

### DIFF
--- a/frontend/src/components/driver-row.js
+++ b/frontend/src/components/driver-row.js
@@ -9,11 +9,9 @@ function DriverRow (props) {
     const gap = props.gap
     const interval = props.interval
 
-    const tyreColour = {
-        "SOFT": "red",
-        "MEDIUM": "yellow",
-        "HARD": "black"
-    }
+    function getKeyByValue(object, value) {
+        return Object.keys(object).find(key => object[key] === value);
+    }      
 
     const convertMillisToLaptime = (millis) => {
         var time = new Date(millis)
@@ -48,7 +46,7 @@ function DriverRow (props) {
             <Col>{convertMillisToSectorTime(telemetry.Sector1Time[Object.keys(telemetry.Sector1Time)[lap]])}</Col>
             <Col>{convertMillisToSectorTime(telemetry.Sector2Time[Object.keys(telemetry.Sector2Time)[lap]])}</Col>
             <Col>{convertMillisToSectorTime(telemetry.Sector3Time[Object.keys(telemetry.Sector3Time)[lap]])}</Col>
-            <Col>{convertMillisToLaptime(telemetry.LapTime[Object.keys(telemetry.LapTime)[lap]])}</Col>
+            <Col style={{color: telemetry.IsPersonalBest[getKeyByValue(telemetry.LapNumber, lap)] ? "lime" : "black"}}>{convertMillisToLaptime(telemetry.LapTime[Object.keys(telemetry.LapTime)[lap]])}</Col>
             <Col style={{color: telemetry.Compound[Object.keys(telemetry.Compound)[lap]] === "SOFT" ? "red" : telemetry.Compound[Object.keys(telemetry.Compound)[lap]] === "MEDIUM" ?  "yellow" : "black"}}>{telemetry.Compound[Object.keys(telemetry.Compound)[lap]]}</Col>
         </>
     )

--- a/frontend/src/components/driver-row.js
+++ b/frontend/src/components/driver-row.js
@@ -1,7 +1,32 @@
-import {Row, Col} from 'reactstrap'
+import { Col } from 'reactstrap'
+import { useEffect, useRef, useState } from 'react'
 
-const DriverRow = (driver, telemetry_lap) => {
-    driver = driver.driver
+function DriverRow (props) {
+
+    const [driver, setDriver] = useState(props.driver)
+    const [telemetry, setTelemetry] = useState(props.telemetry[parseInt(driver.DriverNumber)])
+    const [lap, setLap] = useState(1)
+    const counter = useRef(0)
+
+    // console.log(props.telemetry[parseInt(driver.DriverNumber)])
+
+    useEffect(() => {
+        if (counter.current < 40) {
+            counter.current += 1;
+            const timer = setTimeout(() => setLap(lap + 1), 1000)
+
+            return () => clearTimeout(timer);
+        }
+    }, [lap])
+
+    const convertMillisToLaptime = (millis) => {
+        var time = new Date(millis)
+        var min = time.getMinutes().toString()
+        var sec = time.getSeconds().toString()
+        var mil = ("00" + time.getMilliseconds().toString()).slice(-3)
+
+        return min + ":" + sec + "." + mil
+    }
 
     return(
         <>
@@ -11,8 +36,8 @@ const DriverRow = (driver, telemetry_lap) => {
             <Col>{driver.Abbreviation}</Col>
             <Col>gap</Col>
             <Col>interval</Col>
-            <Col>laptime</Col>
-            <Col>tyre</Col>
+            <Col>{convertMillisToLaptime(telemetry.LapTime[Object.keys(telemetry.LapTime)[lap]])}</Col>
+            <Col>{telemetry.Compound[Object.keys(telemetry.Compound)[lap]]}</Col>
         </>
     )
 }

--- a/frontend/src/components/driver-row.js
+++ b/frontend/src/components/driver-row.js
@@ -1,0 +1,20 @@
+import {Row, Col} from 'reactstrap'
+
+const DriverRow = (driver, telemetry_lap) => {
+    driver = driver.driver
+
+    return(
+        <>
+            <Col style={{textAlign: "right", width: "5px", flexGrow: 0, paddingRight: 0}}>
+                <div className="driverColor" style={{backgroundColor: `#${driver.TeamColor}`}}/>
+            </Col>
+            <Col>{driver.Abbreviation}</Col>
+            <Col>gap</Col>
+            <Col>interval</Col>
+            <Col>laptime</Col>
+            <Col>tyre</Col>
+        </>
+    )
+}
+
+export default DriverRow;

--- a/frontend/src/components/driver-row.js
+++ b/frontend/src/components/driver-row.js
@@ -28,6 +28,19 @@ function DriverRow (props) {
         return min + ":" + sec + "." + mil
     }
 
+    const convertMillisToSectorTime = (millis) => {
+        var time = new Date(millis)
+        var min = time.getMinutes()
+        var sec = time.getSeconds().toString()
+        var mil = ("00" + time.getMilliseconds().toString()).slice(-3)
+
+        if (min > 0){
+            return min + ":" + sec + "." + mil
+        } else {
+            return sec + "." + mil
+        }
+    }
+
     return(
         <>
             <Col style={{textAlign: "right", width: "5px", flexGrow: 0, paddingRight: 0}}>
@@ -36,6 +49,9 @@ function DriverRow (props) {
             <Col>{driver.Abbreviation}</Col>
             <Col>gap</Col>
             <Col>interval</Col>
+            <Col>{convertMillisToSectorTime(telemetry.Sector1Time[Object.keys(telemetry.Sector1Time)[lap]])}</Col>
+            <Col>{convertMillisToSectorTime(telemetry.Sector2Time[Object.keys(telemetry.Sector2Time)[lap]])}</Col>
+            <Col>{convertMillisToSectorTime(telemetry.Sector3Time[Object.keys(telemetry.Sector3Time)[lap]])}</Col>
             <Col>{convertMillisToLaptime(telemetry.LapTime[Object.keys(telemetry.LapTime)[lap]])}</Col>
             <Col>{telemetry.Compound[Object.keys(telemetry.Compound)[lap]]}</Col>
         </>

--- a/frontend/src/components/driver-row.js
+++ b/frontend/src/components/driver-row.js
@@ -9,6 +9,12 @@ function DriverRow (props) {
     const gap = props.gap
     const interval = props.interval
 
+    const tyreColour = {
+        "SOFT": "red",
+        "MEDIUM": "yellow",
+        "HARD": "black"
+    }
+
     const convertMillisToLaptime = (millis) => {
         var time = new Date(millis)
         var min = time.getMinutes().toString()
@@ -43,7 +49,7 @@ function DriverRow (props) {
             <Col>{convertMillisToSectorTime(telemetry.Sector2Time[Object.keys(telemetry.Sector2Time)[lap]])}</Col>
             <Col>{convertMillisToSectorTime(telemetry.Sector3Time[Object.keys(telemetry.Sector3Time)[lap]])}</Col>
             <Col>{convertMillisToLaptime(telemetry.LapTime[Object.keys(telemetry.LapTime)[lap]])}</Col>
-            <Col>{telemetry.Compound[Object.keys(telemetry.Compound)[lap]]}</Col>
+            <Col style={{color: telemetry.Compound[Object.keys(telemetry.Compound)[lap]] === "SOFT" ? "red" : telemetry.Compound[Object.keys(telemetry.Compound)[lap]] === "MEDIUM" ?  "yellow" : "black"}}>{telemetry.Compound[Object.keys(telemetry.Compound)[lap]]}</Col>
         </>
     )
 }

--- a/frontend/src/components/driver-row.js
+++ b/frontend/src/components/driver-row.js
@@ -5,19 +5,14 @@ function DriverRow (props) {
 
     const [driver, setDriver] = useState(props.driver)
     const [telemetry, setTelemetry] = useState(props.telemetry[parseInt(driver.DriverNumber)])
-    const [lap, setLap] = useState(1)
-    const counter = useRef(0)
+    const lap = props.lap
+    
 
     // console.log(props.telemetry[parseInt(driver.DriverNumber)])
 
-    useEffect(() => {
-        if (counter.current < 40) {
-            counter.current += 1;
-            const timer = setTimeout(() => setLap(lap + 1), 1000)
-
-            return () => clearTimeout(timer);
-        }
-    }, [lap])
+    // useEffect(() => {
+        
+    // }, [lap])
 
     const convertMillisToLaptime = (millis) => {
         var time = new Date(millis)

--- a/frontend/src/components/driver-row.js
+++ b/frontend/src/components/driver-row.js
@@ -6,13 +6,8 @@ function DriverRow (props) {
     const [driver, setDriver] = useState(props.driver)
     const [telemetry, setTelemetry] = useState(props.telemetry[parseInt(driver.DriverNumber)])
     const lap = props.lap
-    
-
-    // console.log(props.telemetry[parseInt(driver.DriverNumber)])
-
-    // useEffect(() => {
-        
-    // }, [lap])
+    const gap = props.gap
+    const interval = props.interval
 
     const convertMillisToLaptime = (millis) => {
         var time = new Date(millis)
@@ -42,8 +37,8 @@ function DriverRow (props) {
                 <div className="driverColor" style={{backgroundColor: `#${driver.TeamColor}`}}/>
             </Col>
             <Col>{driver.Abbreviation}</Col>
-            <Col>gap</Col>
-            <Col>interval</Col>
+            <Col>{convertMillisToSectorTime(gap)}</Col>
+            <Col>{convertMillisToSectorTime(interval)}</Col>
             <Col>{convertMillisToSectorTime(telemetry.Sector1Time[Object.keys(telemetry.Sector1Time)[lap]])}</Col>
             <Col>{convertMillisToSectorTime(telemetry.Sector2Time[Object.keys(telemetry.Sector2Time)[lap]])}</Col>
             <Col>{convertMillisToSectorTime(telemetry.Sector3Time[Object.keys(telemetry.Sector3Time)[lap]])}</Col>

--- a/frontend/src/components/telemetry-table.js
+++ b/frontend/src/components/telemetry-table.js
@@ -2,7 +2,7 @@ import { Col, Row, Container } from "reactstrap";
 import { useState, useEffect } from 'react';
 import axios from 'axios';
 import LoadingSpinner from './loading-spinner.js';
-import DriverRow from './driver-row';
+import DriverRow from './driver-row.js';
 import './../styles/components/telemetry.css';
 
 const TelemetryTable = () => {
@@ -22,8 +22,6 @@ const TelemetryTable = () => {
         "7": "Virtual Safety Car Ending"
     }
 
-    // console.log("isLoading: " + isLoading)
-
     useEffect(() => {
         axios.get(
             "/api/telemetry/",
@@ -39,14 +37,11 @@ const TelemetryTable = () => {
             setDrivers(driverlist)
             setTelemetry(telemetry => (res.data.telemetry))
             setLoading(false)
-
-            console.log(telemetry)
         })
         .catch((err) => {
             setError(err)
             setLoading(false)
         })
-        // setLoading(false)
     }, [])
 
     const sortDriversByGridPos = (a, b) => {
@@ -61,7 +56,6 @@ const TelemetryTable = () => {
         let incorrectOrder = true;
         while (incorrectOrder){
             let pole = driverlist[0]
-            // console.log(pole)
             if (pole.GridPosition === 0){
                 let lastplacepos = driverlist[driverlist.length - 1].GridPosition
                 pole.GridPosition = lastplacepos + 1
@@ -76,7 +70,6 @@ const TelemetryTable = () => {
 
 
     if (isLoading){
-        // console.log("isLoading is true.")
         return(
             <LoadingSpinner />
         )
@@ -85,7 +78,6 @@ const TelemetryTable = () => {
             <div>{error}</div>
         )
     } else { 
-        // console.log("React thinks isLoading is false. Actual state: " + isLoading)
         return(
             <Container>
                 <Row>
@@ -100,7 +92,7 @@ const TelemetryTable = () => {
                 {drivers.map((driver, i) => (
                     <Row key={i}>
                         <Col>{i + 1}</Col>
-                        <DriverRow driver={driver}/>
+                        <DriverRow driver={driver} telemetry={telemetry}/>
                     </Row>
                     
                 ))}

--- a/frontend/src/components/telemetry-table.js
+++ b/frontend/src/components/telemetry-table.js
@@ -41,8 +41,6 @@ const TelemetryTable = () => {
 
             calcMissingTimes()
 
-            // console.log(telemetry)
-
             setLoading(false)
         })
         .catch((err) => {
@@ -52,8 +50,6 @@ const TelemetryTable = () => {
     }, [])
 
     useEffect(() =>{
-        // console.log("Current lap: " + lap)
-        // console.log("Current counter: " + counter)
         if (lap < 40) {
             const timer = setTimeout(() => setCounter(counter + 1), 1000)
             
@@ -65,17 +61,9 @@ const TelemetryTable = () => {
                         let driverLap = getKeyByValue(telemetry[driverNum].LapNumber, lap)
                         let lapStart = telemetry[driverNum].LapStartTime[driverLap]
                         driver.CurrentLapStart = lapStart
-                        // driver.kekw = lap
                     }
                     sortDriversByLapStartTimes()
                 }
-                // for (var d in drivers){
-                //     let driver = drivers[d]
-                //     console.log(`Driver ${driver.DriverNumber} lap start time on lap ${lap}: ${driver.CurrentLapStart}`)
-                // }
-                // let kekw = [...drivers]
-                // console.log(kekw)
-                // console.log(drivers, lap)
 
                 setLap(lap + 1);
             }
@@ -90,7 +78,6 @@ const TelemetryTable = () => {
 
     const sortDriversByLapStartTimes = () => {
         setDrivers(drivers => drivers.sort((a, b) => {
-            // console.log(a)
             if (a.CurrentLapStart > b.CurrentLapStart) {
                 return 1
             } else {

--- a/frontend/src/components/telemetry-table.js
+++ b/frontend/src/components/telemetry-table.js
@@ -86,6 +86,9 @@ const TelemetryTable = () => {
                     <Col>NAME</Col>
                     <Col>GAP</Col>
                     <Col>INT</Col>
+                    <Col>S1</Col>
+                    <Col>S2</Col>
+                    <Col>S3</Col>
                     <Col>LAP</Col>
                     <Col>TYRE</Col>
                 </Row>

--- a/frontend/src/components/telemetry-table.js
+++ b/frontend/src/components/telemetry-table.js
@@ -140,6 +140,14 @@ const TelemetryTable = () => {
         return driverlist
     }
 
+    const calculateInterval = (driver, i) => {
+        try{
+            return driver.CurrentLapStart - drivers[i-1].CurrentLapStart
+        } catch(err) {
+            return 0
+        } 
+    }
+
 
     if (isLoading){
         return(
@@ -167,7 +175,7 @@ const TelemetryTable = () => {
                 {drivers.map((driver, i) => (
                     <Row key={driver.DriverNumber}>
                         <Col>{i + 1}</Col>
-                        <DriverRow driver={driver} telemetry={telemetry} lap={lap} setLap={setLap}/>
+                        <DriverRow driver={driver} telemetry={telemetry} lap={lap} gap={driver.CurrentLapStart - drivers[0].CurrentLapStart} interval={calculateInterval(driver, i)}/>
                     </Row>
                     
                 ))}

--- a/frontend/src/components/telemetry-table.js
+++ b/frontend/src/components/telemetry-table.js
@@ -165,7 +165,7 @@ const TelemetryTable = () => {
                     <Col>TYRE</Col>
                 </Row>
                 {drivers.map((driver, i) => (
-                    <Row key={i}>
+                    <Row key={driver.DriverNumber}>
                         <Col>{i + 1}</Col>
                         <DriverRow driver={driver} telemetry={telemetry} lap={lap} setLap={setLap}/>
                     </Row>

--- a/frontend/src/components/telemetry-table.js
+++ b/frontend/src/components/telemetry-table.js
@@ -36,6 +36,11 @@ const TelemetryTable = () => {
 
             setDrivers(driverlist)
             setTelemetry(telemetry => (res.data.telemetry))
+
+            calcMissingTimes()
+
+            console.log(telemetry)
+
             setLoading(false)
         })
         .catch((err) => {
@@ -43,6 +48,23 @@ const TelemetryTable = () => {
             setLoading(false)
         })
     }, [])
+
+    const calcMissingTimes = () => {
+        for (const driver in telemetry){
+            const lap1starttime = telemetry[driver].LapStartTime[Object.keys(telemetry[driver].LapStartTime)[0]]
+            const lap2starttime = telemetry[driver].LapStartTime[Object.keys(telemetry[driver].LapStartTime)[1]]
+
+            const laptime = lap2starttime - lap1starttime
+
+            const s2time = telemetry[driver].Sector2Time[Object.keys(telemetry[driver].Sector2Time)[0]]
+            const s3time = telemetry[driver].Sector3Time[Object.keys(telemetry[driver].Sector3Time)[0]]
+            const s1time = laptime - s2time - s3time
+
+            telemetry[driver].LapTime[Object.keys(telemetry[driver].LapTime)[0]] = laptime
+            telemetry[driver].Sector1Time[Object.keys(telemetry[driver].Sector1Time)[0]] = s1time
+            telemetry[driver].Sector1SessionTime[Object.keys(telemetry[driver].Sector1SessionTime)[0]] = lap1starttime + s1time
+        }
+    }
 
     const sortDriversByGridPos = (a, b) => {
         if (a.GridPosition > b.GridPosition){

--- a/frontend/src/components/telemetry-table.js
+++ b/frontend/src/components/telemetry-table.js
@@ -52,35 +52,30 @@ const TelemetryTable = () => {
     }, [])
 
     useEffect(() =>{
-        console.log("Current lap: " + lap)
+        // console.log("Current lap: " + lap)
         // console.log("Current counter: " + counter)
         if (lap < 40) {
             const timer = setTimeout(() => setCounter(counter + 1), 1000)
             
             if (isLoading === false){
                 if (lap > 0) {
-                    // sortDriversByLapStartTimes()
-
-                    // var driversWithTimes = {}
                     for (var d in drivers){
                         let driver = drivers[d]
                         let driverNum = parseInt(driver.DriverNumber)
                         let driverLap = getKeyByValue(telemetry[driverNum].LapNumber, lap)
                         let lapStart = telemetry[driverNum].LapStartTime[driverLap]
                         driver.CurrentLapStart = lapStart
-
-                        // driversWithTimes[lapStart] = driverNum
+                        // driver.kekw = lap
                     }
                     sortDriversByLapStartTimes()
-                    // drivers.sort((a, b) => a.CurrentLapStart - b.CurrentLapStart)
-                    // console.log(driversWithTimes)
                 }
-                for (var d in drivers){
-                    console.log(d)
-                    let driver = drivers[d]
-                    console.log(`Driver ${driver.DriverNumber} lap start time on lap ${lap}: ${driver.CurrentLapStart}`)
-                }
-                console.log(drivers)
+                // for (var d in drivers){
+                //     let driver = drivers[d]
+                //     console.log(`Driver ${driver.DriverNumber} lap start time on lap ${lap}: ${driver.CurrentLapStart}`)
+                // }
+                // let kekw = [...drivers]
+                // console.log(kekw)
+                // console.log(drivers, lap)
 
                 setLap(lap + 1);
             }

--- a/frontend/src/components/telemetry-table.js
+++ b/frontend/src/components/telemetry-table.js
@@ -74,7 +74,7 @@ const TelemetryTable = () => {
 
     function getKeyByValue(object, value) {
         return Object.keys(object).find(key => object[key] === value);
-      }      
+    }      
 
     const sortDriversByLapStartTimes = () => {
         setDrivers(drivers => drivers.sort((a, b) => {

--- a/frontend/src/pages/secondscreen.js
+++ b/frontend/src/pages/secondscreen.js
@@ -13,9 +13,9 @@ export const SecondScreen = () => {
     return(
         <div>
             <h1>This is the second screen page.</h1>
-            <TelemetryTable />
-            <TwitterFeed />
-            <RedditFeed />
+            {telemetry ? <TelemetryTable /> : <></>}
+            {twitter ? <TwitterFeed /> : <></>}
+            {reddit ? <RedditFeed /> : <></>}
         </div>
     )
 }

--- a/server/honoursProject/views.py
+++ b/server/honoursProject/views.py
@@ -76,7 +76,7 @@ class TelemetryView(viewsets.ViewSet):
             for driver in session.drivers:
                 print(f"Getting data for driver {driver}.")
                 t = session.laps.pick_driver(driver)
-                print(f"Converting to dict...\n")
+                print(f"Converting to JSON...\n")
                 telemetry[driver] = t.to_json()
                 print(f"Parsing information for driver{driver}...")
                 drivers[str(driver)] = session.get_driver(driver).to_json()


### PR DESCRIPTION
Live telemetry is now displayed (1 lap every second). The whole table updated simultaneously, which will eventually be reworked so that individual driver's sectors are displayed as soon as they are set, as well as making the whole table work in real-time. Also currently only displays 40 laps, will be reworked to show all racing laps.